### PR TITLE
Fix package.xml and CMakeLists.txt to actually compile msgs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,10 @@ project(sar_game_command_msgs)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
-  rospy
-  std_msgs
-)
+	roscpp
+	rospy
+	std_msgs
+	message_generation)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -43,11 +44,11 @@ find_package(catkin REQUIRED COMPONENTS
 ##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
 
 ## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
+ add_message_files(
+   FILES
+   GameCommand.msg
+   GameState.msg
+ )
 
 ## Generate services in the 'srv' folder
 # add_service_files(
@@ -64,10 +65,10 @@ find_package(catkin REQUIRED COMPONENTS
 # )
 
 ## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs
-# )
+ generate_messages(
+   DEPENDENCIES
+   std_msgs
+ )
 
 ################################################
 ## Declare ROS dynamic reconfigure parameters ##
@@ -101,7 +102,7 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES sar_game_command_msgs
-#  CATKIN_DEPENDS rospy std_msgs
+  CATKIN_DEPENDS message_runtime std_msgs
 #  DEPENDS system_lib
 )
 

--- a/package.xml
+++ b/package.xml
@@ -2,24 +2,24 @@
 <package>
   <name>sar_game_command_msgs</name>
   <version>0.0.0</version>
-  <description>The sar_game_command_msgs package</description>
+  <description>Command messages for telling SAR games what to do</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag --> 
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
-  <maintainer email="sar@todo.todo">sar</maintainer>
+  <maintainer email="chien-ming.huang@yale.edu">Chien-Ming Huang</maintainer>
 
 
   <!-- One license tag required, multiple allowed, one license per tag -->
   <!-- Commonly used license strings: -->
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
+  <license>MIT</license>
 
 
   <!-- Url tags are optional, but mutiple are allowed, one per tag -->
   <!-- Optional attribute type can be: website, bugtracker, or repository -->
   <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/sar_game_command_msgs</url> -->
+  <url type="website">https://github.com/sociallyassistiverobotics/sar_game_command_msgs</url>
 
 
   <!-- Author tags are optional, mutiple are allowed, one per tag -->
@@ -40,10 +40,10 @@
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
-  <run_depend>rospy</run_depend>
+  <build_depend>message_generation</build_depend>
   <run_depend>std_msgs</run_depend>
+  <run_depend>message_runtime</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
When running catkin_make, the messages in sar_game_command_msgs are not generated. The issue is that the package.xml and CMakeLists.txt files do not list the correct dependencies or list of message files to generate.

This fix will:
- Add required components list, list of message files to generate, and
  dependency list to CMakeLists.txt.
- Add message_generation and message_runtime as dependencies to
  package.xml.
- Add package description, maintainer email, website, and license to
  package.xml.
