### PR TITLE
Add info on level, performance fields to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-# sar_game_command_msgs
+# sar\_game\_command\_msgs
 
 A ROS package containing custom ROS messages for communication with SAR games.
 
 # GameCommand
 
-The GameCommand message is used to issue commands to SAR games. This message includes two fields, `game` and `command`, and a set of constants for these two fields.
+The GameCommand message is used to issue commands to SAR games. This message
+includes two fields, `game` and `command`, and a set of constants for these two
+fields.
 
 The `game` field describes which game to take the commands.
 TODO: This field is still under experiment.
@@ -16,7 +18,8 @@ The constants for this field are listed below.
 TODO: more to add
 
 
-The `command` field specifies the command that the receiving game should do. A list of constants for this field is summarized below.
+The `command` field specifies the command that the receiving game should do. A
+list of constants for this field is summarized below.
 
 - START (0)
 
@@ -24,7 +27,8 @@ Upon receiving this command, the game starts to play.
 
 - CONTINUE (1)
 
-This command is expected after a `PAUSE` command. Upon receiving this command, the game resumes to play.
+This command is expected after a `PAUSE` command. Upon receiving this command,
+the game resumes to play.
 
 - PAUSE (2)
 
@@ -32,27 +36,31 @@ This command puts the game on hold.
 
 - END (3)
 
-Upon receiving this command, the game exits gracefully (e.g., continue to play until the next reasonable exit point). Do not exit the game abruptly.
+Upon receiving this command, the game exits gracefully (e.g., continue to play
+until the next reasonable exit point). Do not exit the game abruptly.
 
 # GameState
 
-The GameState message sends the state of the publishing game. This message includes two fields, `game` and `state`, and a set of constants for these two fields.
- 
+The GameState message sends the state of the publishing game. This message
+includes two fields, `game` and `state`, and a set of constants for these two
+fields.
+
 The game field is the same as the one in GameCommand described above.
 
 The state field takes the following constants.
 
 - START (0)
-- IN_PROGRESS (1)
+- IN\_PROGRESS (1)
 - PAUSED (2)
-- USER_TIMEOUT (3)
+- USER\_TIMEOUT (3)
 - END (4)
 
 # When to publish a game state
 
 `GameState.START`: when receiving a GameCommand.START
 
-`GameState.IN_PROGRESS`: when receiving a GameCommand.START and GameCommand.CONTINUE
+`GameState.IN_PROGRESS`: when receiving a GameCommand.START and
+GameCommand.CONTINUE
 
 `GameState.PAUSED`: when receiving a GameCommand.PAUSE
 

--- a/README.md
+++ b/README.md
@@ -13,17 +13,29 @@ includes the following fields and a set of constants for these fields:
     - TODO: more to add
 
 - `command`: Specifies the command for the receiving game. This command could
-  be any of the following:
-    - START (0): Upon receiving this command, the game starts to play.
-    - CONTINUE (1): This command is expected after a `PAUSE` command. Upon
-      receiving this command, the game resumes to play.
-    - PAUSE (2): This command puts the game on hold.
-    - END (3): Upon receiving this command, the game exits gracefully (e.g.,
-      continue to play until the next reasonable exit point). Do not exit the
-      game abruptly.
+  be any of the following (use cases described below):
+    - START (0)
+    - CONTINUE (1)
+    - PAUSE (2)
+    - END (3)
 
 - `level`: Include when sending a `GameCommand.START` message. Specifies the
   level the game should start at.
+
+### Expected game behavior
+
+Upone receiving each command, the game should...
+
+`GameCommand.START`: Start to play.
+
+`GameCommand.CONTINUE`: Resume play. This command is expected to be send after
+a `GameCommand.PAUSE` command.
+
+`GameCommand.PAUSE`: Pause game play until a `GameState.CONTINUE` message is
+received.
+
+`GameCommand.END`: Exits gameplay gracefully. That is, continue to play until
+the next reasonable exit point. Do not exit the game abruptly.
 
 ## GameState
 
@@ -47,13 +59,19 @@ includes the following fields and a set of constants for these fields:
 
 ### When to publish a GameState message
 
-`GameState.START`: when receiving a GameCommand.START
+A game should publish `GameCommand` messages at the following times:
 
-`GameState.IN_PROGRESS`: when receiving a GameCommand.START and
-GameCommand.CONTINUE
+`GameState.START`: When a `GameCommand.START` message has been received and the
+game is starting.
 
-`GameState.PAUSED`: when receiving a GameCommand.PAUSE
+`GameState.IN_PROGRESS`: When either a `GameCommand.START` or a
+`GameCommand.CONTINUE` message has been received, to indicate that the game is
+continuing now.
 
-`GameState.TIMEOUT`: not receiving responses from the user
+`GameState.PAUSED`: When a `GameCommand.PAUSE` message has been received and
+the game is paused.
 
-`GameState.END`: after wrapping up the game
+`GameState.TIMEOUT`: If a response was expected from the user, but no response
+was received within a reasonable amount of time.
+
+`GameState.END`: After wrapping up the game, when gameplay has ended.

--- a/README.md
+++ b/README.md
@@ -2,60 +2,50 @@
 
 A ROS package containing custom ROS messages for communication with SAR games.
 
-# GameCommand
+## GameCommand
 
 The GameCommand message is used to issue commands to SAR games. This message
-includes two fields, `game` and `command`, and a set of constants for these two
-fields.
+includes the following fields and a set of constants for these fields:
 
-The `game` field describes which game to take the commands.
-TODO: This field is still under experiment.
+- `game`: A constant listing which game should pay attention the command.
+  TODO: This field is still under experiment. The available games are:
+    - STORYTELLING (0)
+    - TODO: more to add
 
-The constants for this field are listed below.
+- `command`: Specifies the command for the receiving game. This command could
+  be any of the following:
+    - START (0): Upon receiving this command, the game starts to play.
+    - CONTINUE (1): This command is expected after a `PAUSE` command. Upon
+      receiving this command, the game resumes to play.
+    - PAUSE (2): This command puts the game on hold.
+    - END (3): Upon receiving this command, the game exits gracefully (e.g.,
+      continue to play until the next reasonable exit point). Do not exit the
+      game abruptly.
 
-- STORYTELLING (0)
+- `level`: Include when sending a `GameCommand.START` message. Specifies the
+  level the game should start at.
 
-TODO: more to add
-
-
-The `command` field specifies the command that the receiving game should do. A
-list of constants for this field is summarized below.
-
-- START (0)
-
-Upon receiving this command, the game starts to play.
-
-- CONTINUE (1)
-
-This command is expected after a `PAUSE` command. Upon receiving this command,
-the game resumes to play.
-
-- PAUSE (2)
-
-This command puts the game on hold.
-
-- END (3)
-
-Upon receiving this command, the game exits gracefully (e.g., continue to play
-until the next reasonable exit point). Do not exit the game abruptly.
-
-# GameState
+## GameState
 
 The GameState message sends the state of the publishing game. This message
-includes two fields, `game` and `state`, and a set of constants for these two
-fields.
+includes the following fields and a set of constants for these fields:
 
-The game field is the same as the one in GameCommand described above.
+- `game`: The same as the one in GameCommand described above.
 
-The state field takes the following constants.
+- `state`: Set to one of the following constants (use cases listed below):
+    - START (0)
+    - IN\_PROGRESS (1)
+    - PAUSED (2)
+    - USER\_TIMEOUT (3)
+    - END (4)
 
-- START (0)
-- IN\_PROGRESS (1)
-- PAUSED (2)
-- USER\_TIMEOUT (3)
-- END (4)
+- `performance`: Include when you send a `GameState.END` message. Should
+  contain the player's sucess rate for the game's primary target skill (e.g.,
+  ordering/sequencing, perspective taking, emotional understanding) as a
+  decimal percentage (i.e., the number of successes or correct answers divided
+  by the number of opportunities for success).
 
-# When to publish a game state
+### When to publish a GameState message
 
 `GameState.START`: when receiving a GameCommand.START
 

--- a/msg/GameCommand.msg
+++ b/msg/GameCommand.msg
@@ -1,11 +1,11 @@
-# Message for requesting game actions 
+# Message for requesting game actions
 Header header
 
 # which game
 int8 game
 
-# which command 
-int8 command 
+# which command
+int8 command
 
 # which level to play
 int8 level

--- a/msg/GameState.msg
+++ b/msg/GameState.msg
@@ -5,7 +5,7 @@ Header header
 int8 game
 
 # which state
-int8 state 
+int8 state
 
 # user performance
 float32 performance
@@ -20,4 +20,3 @@ int8 IN_PROGRESS = 1
 int8 PAUSED = 2
 int8 USER_TIMEOUT = 3
 int8 END = 4
- 


### PR DESCRIPTION
Currently, there is information missing in the README about how and when to use the `level` and `performance` fields in `GameCommand` and `GameState` messages, respectively.

These changes would:
- Add necessary information about the `level` and `performance` fields to the README.
- Update formatting in the README to be more readable, including:
  - Wrap lines at 80 characters.
  - Put message fields in bulleted lists.
  - Use markdown subheadings.
- In all files, remove trailing whitespace.
