### PR TITLE
Add WAIT_FOR_RESPOND and SKIP_RESPONSE commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,16 @@ If the game receives a player response, it can continue as normal; if it does
 not, it should send a `GameState.USER_TIMEOUT` message to indicate that no
 response was received.
 
-`GameCommand.SKIP\_RESPONSE`: Resume play, optionally taking additional action
+`GameCommand.SKIP_RESPONSE`: Resume play, optionally taking additional action
 to reflect the fact that an expected user response was not received.
 
 ## GameState
 
-The GameState message sends the state of the publishing game. This message
-includes the following fields and a set of constants for these fields:
+The GameState messages are sent by games to indicate what's happening in the
+game. This message includes the following fields and a set of constants for
+these fields:
 
-- `game`: The same as the one in GameCommand described above.
+- `game`: The same as for `GameCommand`, described above.
 
 - `state`: Set to one of the following constants (use cases listed below):
     - START (0)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ includes the following fields and a set of constants for these fields:
     - CONTINUE (1)
     - PAUSE (2)
     - END (3)
+    - WAIT\_FOR\_RESPONSE (4)
+    - SKIP\_RESPONSE (5)
 
 - `level`: Include when sending a `GameCommand.START` message. Specifies the
   level the game should start at.
@@ -36,6 +38,14 @@ received.
 
 `GameCommand.END`: Exits gameplay gracefully. That is, continue to play until
 the next reasonable exit point. Do not exit the game abruptly.
+
+`GameCommand.WAIT_FOR_RESPONSE`: Wait for a player response before continuing.
+If the game receives a player response, it can continue as normal; if it does
+not, it should send a `GameState.USER_TIMEOUT` message to indicate that no
+response was received.
+
+`GameCommand.SKIP\_RESPONSE`: Resume play, optionally taking additional action
+to reflect the fact that an expected user response was not received.
 
 ## GameState
 
@@ -64,14 +74,16 @@ A game should publish `GameCommand` messages at the following times:
 `GameState.START`: When a `GameCommand.START` message has been received and the
 game is starting.
 
-`GameState.IN_PROGRESS`: When either a `GameCommand.START` or a
-`GameCommand.CONTINUE` message has been received, to indicate that the game is
-continuing now.
+`GameState.IN_PROGRESS`: When a `GameCommand.START`, `GameCommand.CONTINUE`, or
+`GameCommand.SKIP\_RESPONSE` message has been received, to indicate that the
+game is continuing play now.
 
 `GameState.PAUSED`: When a `GameCommand.PAUSE` message has been received and
 the game is paused.
 
-`GameState.TIMEOUT`: If a response was expected from the user, but no response
-was received within a reasonable amount of time.
+`GameState.USER_TIMEOUT`: If a response was expected from the user, but no
+response was received within a reasonable amount of time. The game should PAUSE
+after it sends this message to wait for instructions regarding whether it
+should wait for a response again or skip the response and move on.
 
 `GameState.END`: After wrapping up the game, when gameplay has ended.

--- a/msg/GameCommand.msg
+++ b/msg/GameCommand.msg
@@ -19,3 +19,5 @@ int8 START = 0
 int8 CONTINUE = 1
 int8 PAUSE = 2
 int8 END = 3
+int8 WAIT_FOR_RESPONSE = 4
+int8 SKIP_RESPONSE = 5


### PR DESCRIPTION
Depends on #4 for README formatting. If #4 gets merged first, this request will only be adding the new commands described below, plus corresponding documentation in the README.
## 

This pull request adds two new GameCommand commands: `WAIT_FOR_RESPONSE` and `SKIP_RESPONSE`. 

After a game sends a `GameState.USER_TIMEOUT` message to indicate that it timed out waiting for a user to response, it pauses and waits for a `GameCommand` message to tell it what to do next. It should be either a `GameCommand.WAIT_FOR_RESPONSE` message to indicate that it
should try waiting for a response again, or a `GameCommand.SKIP_RESPONSE` message to indicate that it should skip waiting for the user response.

The main reason for adding the `GameCommand.SKIP_RESPONSE` message is to allow game to easily take different actions after receiving `GameCommand.SKIP_RESPONSE` versus `GameCommand.CONTINUE` messages. For example, if the game had been waiting for a user response, it may want to take some additional action before resuming normal game play to reflect the fact that it didn't get the expected response, while if the game had merely been paused and told to continue, it would simply pick up where it had left off.

(An alternate option would be to _not_ have the `GameCommand.SKIP_RESPONSE` message. In this case, games would receive a `GameCommand.CONTINUE` message after any kind of event requiring the game to pause or wait. So a game would need to internally track whether it had received a  `GameCommand.PAUSE` message prior to the `CONTINUE` or whether they had recently sent a `GameState.USER_TIMEOUT` message to know what actions to take. That seems messier to me, thus the proposed `GameCommand.SKIP_RESPONSE`.)
