### PR TITLE
Add version number

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <package>
   <name>sar_game_command_msgs</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>Command messages for telling SAR games what to do</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="chien-ming.huang@yale.edu">Chien-Ming Huang</maintainer>


### PR DESCRIPTION
Currently, there is no version number listed for this package.

It would be useful to be able to reference which version of this package is being used, e.g., when listing dependencies for another project. That way, it's easy to say things like "This project has been tested with version 1.0.0 of [sar_game_command_msgs](https://github.com/sociallyassistiverobotics/sar_game_command_msgs)", and know that when sar_game_command_msgs are updated to a newer version, we may have to test or upgrade the project that uses them.

I recommend using [semantic versioning](http://semver.org/).

I've added a version number to the package information. After merging this pull request, you can tag a release as follows from your local command line:
1. `git tag -a v1.0.0` (create a tag titled "v1.0.0" and add a description)
2. Enter a description of the version (see [the tag on my fork here](https://github.com/jakory/sar_game_command_msgs/releases/tag/v1.0.0)), save and commit.
3. `git push origin --tags` (will push the tag to the configured upstream repository)
4. From the github web interface in the "Code" tab, you can click on "Releases", then "Tags", and there's a button to "Add release notes" where you can enter a description of the version (can be the same as what you entered for the tag).
